### PR TITLE
feat(stylistic): enforce member delimiter style

### DIFF
--- a/configs/index.mjs
+++ b/configs/index.mjs
@@ -63,6 +63,19 @@ export default [
         avoidEscape: true,
       }],
       '@stylistic/semi': ['error', 'never'],
+      '@stylistic/member-delimiter-style': [
+        'error',
+        {
+          'multiline': {
+            'delimiter': 'none', // No delimiter for multiline
+            'requireLast': false,
+          },
+          'singleline': {
+            'delimiter': 'comma', // Use a comma for single-line
+            'requireLast': false,
+          },
+        },
+      ],
       '@stylistic/space-before-function-paren': ['error', {
         anonymous: 'never',
         named: 'never',


### PR DESCRIPTION
Prevent the use of semicolons in multiline interfaces and inside single line interfaces.

## Correct
```typescript
// Multiline interface (no delimiters)
interface MultilineExample {
  name: string // Correct: no semicolon or comma
  age: number // Correct: no semicolon or comma
}

// Single-line interface (comma-delimited)
interface SinglelineExample { name: string, age: number } // Correct: comma between properties
```

## Incorrect

```typescript
// Multiline interface (no semicolon or comma allowed)
interface MultilineExample {
  name: string; // Incorrect: semicolon used
  age: number, // Incorrect: comma used
}

// Single-line interface (comma required)
interface SinglelineExample { name: string; age: number } // Incorrect: no comma between properties
```