### PR TITLE
feat: add package.json property sorting configuration [KHCP-19131]

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ import eslintKongUiConfigCypress from '@kong/eslint-config-kong-ui/cypress'
 > [!Note]
 > You will likely only want to apply the Cypress config to a subset of file patterns in your project. See the section on [applying a config to a subset of files](#apply-a-config-to-a-subset-of-files) for detailed instructions.
 
+#### Package.json config
+
+The Package.json config provides property sorting for `package.json` files and includes rules configured via `eslint-plugin-jsonc`. It enforces a consistent order of properties in your `package.json` files and sorts dependencies alphabetically.
+
+> [!Note]
+> **This config is automatically included** in the [Default config](#default-config), so you don't need to import it separately. It will automatically apply to all `**/package.json` files when you use `@kong/eslint-config-kong-ui`.
+
+The property order follows common conventions with metadata fields first, followed by exports, scripts, dependencies, and repository information.
+
+If you need to use it separately (e.g., in a custom setup), it can be imported like this:
+
+```javascript
+import eslintKongUiConfigPackageJson from '@kong/eslint-config-kong-ui/package-json'
+```
+
 ### Setup
 
 To use the shared config, import the package inside of an `eslint.config.mjs` file and add it into the exported array, like this:
@@ -127,6 +142,7 @@ import eslintKongUiConfigCypress from '@kong/eslint-config-kong-ui/cypress'
 
 export default [
   // Use the main config for all other files
+  // (package.json sorting is automatically included)
   ...eslintKongUiConfig,
   // Only apply the shared JSON config to files that match the given pattern
   ...eslintKongUiConfigJson.map(config => ({

--- a/configs/index.mjs
+++ b/configs/index.mjs
@@ -5,6 +5,7 @@ import pluginVue from 'eslint-plugin-vue'
 import pluginPromise from 'eslint-plugin-promise'
 import stylistic from '@stylistic/eslint-plugin'
 import globals from 'globals'
+import packageJsonConfig from './package-json.mjs'
 
 const stylisticRules = {
   '@stylistic/indent': ['error', 2],
@@ -214,4 +215,6 @@ export default [
       '@typescript-eslint/no-var-requires': 'off',
     },
   },
+  // Include package.json sorting by default
+  ...packageJsonConfig,
 ]

--- a/configs/package-json.mjs
+++ b/configs/package-json.mjs
@@ -1,0 +1,74 @@
+import eslintPluginJsonc from 'eslint-plugin-jsonc'
+import jsonParser from 'jsonc-eslint-parser'
+
+export default [
+  {
+    files: ['**/package.json'],
+    languageOptions: {
+      parser: jsonParser,
+    },
+    plugins: {
+      jsonc: eslintPluginJsonc,
+    },
+    rules: {
+      // Sort the files array alphabetically
+      'jsonc/sort-array-values': [
+        'error',
+        {
+          order: { type: 'asc' },
+          pathPattern: '^files$',
+        },
+      ],
+      // Sort the keys in package.json
+      'jsonc/sort-keys': [
+        'error',
+        {
+          // Top-level properties order
+          order: [
+            'name',
+            'version',
+            'description',
+            'type',
+            'main',
+            'files',
+            'exports',
+            'publishConfig',
+            'scripts',
+            'dependencies',
+            'peerDependencies',
+            'devDependencies',
+            'pnpm',
+            'repository',
+            'keywords',
+            'author',
+            'license',
+            'bugs',
+            'homepage',
+            'release',
+          ],
+          pathPattern: '^$',
+        },
+        {
+          // Sort dependency objects alphabetically
+          order: { type: 'asc' },
+          pathPattern: '^(?:dev|peer|optional)?[Dd]ependencies$',
+        },
+        {
+          // Sort scripts alphabetically
+          order: { type: 'asc' },
+          pathPattern: '^scripts$',
+        },
+        {
+          // Sort exports object
+          order: { type: 'asc' },
+          pathPattern: '^exports$',
+        },
+        {
+          // Sort pnpm object
+          order: { type: 'asc' },
+          pathPattern: '^pnpm$',
+        },
+      ],
+    },
+  },
+]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,10 @@ import eslintKongUiConfigJson from './configs/json.mjs'
 import eslintKongUiConfigCypress from './configs/cypress.mjs'
 
 export default [
+  // Global ignores
+  {
+    ignores: ['fixtures/'],
+  },
   // Use the main config for all files
   ...eslintKongUiConfig,
   // Only apply the shared JSON config to files that match the given pattern

--- a/package.json
+++ b/package.json
@@ -2,26 +2,27 @@
   "name": "@kong/eslint-config-kong-ui",
   "version": "1.6.0",
   "description": "Sharable ESLint configuration for Kong's frontend repositories",
-  "main": "configs/index.mjs",
   "type": "module",
+  "main": "configs/index.mjs",
   "files": [
     "configs"
   ],
   "exports": {
     ".": "./configs/index.mjs",
+    "./cypress": "./configs/cypress.mjs",
     "./default": "./configs/index.mjs",
     "./json": "./configs/json.mjs",
-    "./cypress": "./configs/cypress.mjs",
+    "./package-json": "./configs/package-json.mjs",
     "./package.json": "./package.json"
   },
   "publishConfig": {
     "access": "public"
   },
   "scripts": {
+    "commit": "cz",
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "semantic-release": "semantic-release",
-    "commit": "cz"
+    "semantic-release": "semantic-release"
   },
   "dependencies": {
     "@eslint/js": "^9.37.0",


### PR DESCRIPTION
# Description

inspired by http://github.com/antfu/eslint-config

this PR adds `package.json` property sorting configuration so we have the same order across kong repositories