### PR TITLE
feat: integrate '@kong/eslint-plugin-design-tokens'

### DIFF
--- a/configs/index.mjs
+++ b/configs/index.mjs
@@ -5,6 +5,7 @@ import pluginVue from 'eslint-plugin-vue'
 import pluginPromise from 'eslint-plugin-promise'
 import stylistic from '@stylistic/eslint-plugin'
 import globals from 'globals'
+import designTokensPlugin from '@kong/eslint-plugin-design-tokens'
 
 const stylisticRules = {
   '@stylistic/indent': ['error', 2],
@@ -136,6 +137,7 @@ export default [
     },
     plugins: {
       '@stylistic': stylistic,
+      '@kong/eslint-plugin-design-tokens': designTokensPlugin,
     },
     ignores: [
       '**/locales/**/*.json',
@@ -212,6 +214,7 @@ export default [
         },
       ],
       'vue/require-default-prop': 'off',
+      '@kong/eslint-plugin-design-tokens/token-constant-requires-css-var': 'error',
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "@eslint/js": "^9.37.0",
+    "@kong/eslint-plugin-design-tokens": "^0.0.1",
     "@stylistic/eslint-plugin": "^5.4.0",
     "eslint-plugin-cypress": "^5.2.0",
     "eslint-plugin-jsonc": "^2.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ importers:
       '@eslint/js':
         specifier: ^9.37.0
         version: 9.37.0
+      '@kong/eslint-plugin-design-tokens':
+        specifier: ^0.0.1
+        version: 0.0.1(eslint@9.37.0(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.4.2)))
       '@stylistic/eslint-plugin':
         specifier: ^5.4.0
         version: 5.4.0(eslint@9.37.0(jiti@2.4.2))
@@ -278,6 +281,16 @@ packages:
   '@humanwhocodes/retry@0.4.2':
     resolution: {integrity: sha512-xeO57FpIu4p1Ri3Jq/EXq4ClRm86dVF2z/+kvFnyqVYRavTZmaFaUBbWCOuuTh0o/g7DSsk6kc2vrS4Vl5oPOQ==}
     engines: {node: '>=18.18'}
+
+  '@kong/eslint-plugin-design-tokens@0.0.1':
+    resolution: {integrity: sha512-bpiHNav0EsWNZ1R6dPsFoAg0lOzzT5FXKjmH8qgxyGYY4YqGB9ObKmA57SLapCy85jloWuH2R/s5Z9r+O6ZJeg==}
+    engines: {node: '>=20.19.5', pnpm: '>=10.28.2'}
+    peerDependencies:
+      eslint: ^9.0.0
+      vue-eslint-parser: '>=10.2.0'
+    peerDependenciesMeta:
+      vue-eslint-parser:
+        optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
@@ -2920,6 +2933,12 @@ snapshots:
   '@humanwhocodes/retry@0.3.0': {}
 
   '@humanwhocodes/retry@0.4.2': {}
+
+  '@kong/eslint-plugin-design-tokens@0.0.1(eslint@9.37.0(jiti@2.4.2))(vue-eslint-parser@10.2.0(eslint@9.37.0(jiti@2.4.2)))':
+    dependencies:
+      eslint: 9.37.0(jiti@2.4.2)
+    optionalDependencies:
+      vue-eslint-parser: 10.2.0(eslint@9.37.0(jiti@2.4.2))
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:


### PR DESCRIPTION
Integrate `@kong/eslint-plugin-design-tokens` into our standard eslint rules package.

This enforces the ESLint plugin from https://github.com/Kong/design-tokens/pull/656 and may require running `eslint --fix` in consuming repos